### PR TITLE
gradle: Validate distribution using SHA256 checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
## Summary

Validate Gradle distributions using SHA256 checksums before downloading and using them. This checksum has been obtained from official Gradle docs [here](https://gradle.org/release-checksums/)

## Reference Links

- https://gitlab.com/fdroid/rfp/-/issues/2742
- https://blog.gradle.org/project-integrity
- https://commonsware.com/blog/2023/01/25/gradle-wrapper-supply-chain-attack.html
- https://commonsware.com/blog/2021/01/27/checking-poisoned-projects.html