### PR TITLE
[AI-generated]Fix crash on Android 8.x (API 26-27) due to PermissionInfo.getProtectionFlags()  

### DIFF
--- a/app/src/main/java/com/rosan/dhizuku/server/DhizukuState.kt
+++ b/app/src/main/java/com/rosan/dhizuku/server/DhizukuState.kt
@@ -52,7 +52,12 @@ data object DhizukuState {
         val permissions = getAllRequestedPermissions(context, admin).filter {
             it ?: return@filter false
             val permission = getPermissionInfo(context, it) ?: return@filter false
-            return@filter permission.protectionFlags.has(PermissionInfo.PROTECTION_DANGEROUS)
+            return@filter if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                permission.protectionFlags.has(PermissionInfo.PROTECTION_DANGEROUS)
+            } else {
+                @Suppress("DEPRECATION")
+                (permission.protectionLevel and PermissionInfo.PROTECTION_MASK_BASE) == PermissionInfo.PROTECTION_DANGEROUS
+            }
         }
 
         permissions.forEach {


### PR DESCRIPTION
Fixes #304, #314, #315

## Problem

Dhizuku crashes immediately on startup (`Application.onCreate()`) on Android 8.0/8.1 (API 26–27) devices with:

java.lang.NoSuchMethodError: No virtual method getProtectionFlags()I
in class Landroid/content/pm/PermissionInfo;

`PermissionInfo.getProtectionFlags()` was introduced in API 28 (Android P), but the project declares `minSdk = 26`. Kotlin resolves `permission.protectionFlags` as a call to this getter, which does not exist on older devices.

As noted in #304, this is especially serious because once DeviceOwner is active, the crash leaves the app unrecoverable (`pm clear`, `pm uninstall`, `dpm remove-active-admin`, and downgrade all fail), forcing a factory reset.

## Fix

Added a `Build.VERSION.SDK_INT` check in `DhizukuState.grantPermissions()`:
- **API 28+**: continues using `getProtectionFlags()` (unchanged behavior)
- **API 26–27**: falls back to the deprecated `protectionLevel` field with `PROTECTION_MASK_BASE` bitmask to extract the base protection level

Only one call site was affected (`DhizukuState.kt` line 55). No functional changes intended — this is meant to be a pure backward-compatibility fix.

## ⚠️ Important — Please review carefully

**This code was entirely generated by Claude (AI).** I do **not** have a second device to test on, so **this change has NOT been verified on real hardware** — neither on Android 8.x nor on newer versions. The only "review" it received was from Claude in a separate window.

Please review this thoroughly and carefully before merging, and ideally verify it on an actual API 26–27 device. Treat this as a starting point / suggestion rather than a validated fix.