### PR TITLE
feat: Add Account & User Manager, optimize M3 transitions and fix activation bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build Release APK
+        run: |
+          ./gradlew --no-daemon assembleRelease
+
+      - name: Rename APK
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk app/build/outputs/apk/release/Dhizuku-${{ github.ref_name }}.apk
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app/build/outputs/apk/release/Dhizuku-${{ github.ref_name }}.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,21 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: app/build/outputs/apk/release/Dhizuku-${{ github.ref_name }}.apk
+          generate_release_notes: true
+          body: |
+            ## Dhizuku v2.13.0 (20) 正式优化版
+            
+            **更新日志 (Changelog):**
+            - **【核心新增】一键冻结与解冻**：新增账号管理器与用户管理面板，支持一键对全体账户进行冷冻/解冻，并在右上角锁图标处配备了加载等待提示。
+            - **【动效美化】Material 3 过渡与微交互**：
+              - 全局导航切换为标准的水平共享轴滑移 + 渐隐渐现动效。
+              - 冻结列表卡片不透明度与屏蔽列表底色升级为平滑插值渐变。
+              - 冻结成功后的小锁标志采用缩放弹性淡入淡出（Micro-animations）。
+            - **【漏洞修复】高并发与消失Bug**：
+              - 修复了连续快速解冻/冻结导致应用列表瞬间消失、闪烁或状态覆盖的底层竞态条件。
+              - 修复长包名应用（如 HMS Core）锁标志被挤出屏幕边缘的排版缺陷。
+            - **【激活修复】拒绝虚假成功**：
+              - 修复了在账户未清空状态下激活 Device Owner 出现“假成功”弹窗的问题，现在能准确拦截并提供重试。
+              - 补全了 Shizuku 激活成功后的状态即时同步刷新与后台自动授权。
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/src/main/java/com/rosan/dhizuku/data/account/entity/AccountAuthenticatorEntity.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/account/entity/AccountAuthenticatorEntity.kt
@@ -1,0 +1,11 @@
+package com.rosan.dhizuku.data.account.entity
+
+import android.graphics.drawable.Drawable
+
+data class AccountAuthenticatorEntity(
+    val userId: Int,
+    val type: String,
+    val packageName: String,
+    val label: String,
+    val icon: Drawable
+)

--- a/app/src/main/java/com/rosan/dhizuku/data/account/entity/AccountEntity.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/account/entity/AccountEntity.kt
@@ -1,0 +1,7 @@
+package com.rosan.dhizuku.data.account.entity
+
+data class AccountEntity(
+    val userId: Int,
+    val type: String,
+    val name: String
+)

--- a/app/src/main/java/com/rosan/dhizuku/data/account/entity/UserEntity.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/account/entity/UserEntity.kt
@@ -1,0 +1,6 @@
+package com.rosan.dhizuku.data.account.entity
+
+data class UserEntity(
+    val id: Int,
+    val name: String?
+)

--- a/app/src/main/java/com/rosan/dhizuku/data/account/model/ShizukuUserService.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/account/model/ShizukuUserService.kt
@@ -1,0 +1,273 @@
+package com.rosan.dhizuku.data.account.model
+
+import android.accounts.Account
+import android.accounts.IAccountManager
+import android.accounts.IAccountManagerResponse
+import android.content.Context
+import android.content.pm.IPackageManager
+import android.content.pm.PackageInfo
+import android.os.Build
+import android.os.Bundle
+import android.os.IUserManager
+import android.os.RemoteException
+import com.rosan.dhizuku.data.common.util.dumpText
+import com.rosan.dhizuku.data.common.util.getParcelableCompat
+import com.rosan.dhizuku.data.common.util.requireShizukuPermissionGranted
+import com.rosan.dhizuku.data.common.util.shizukuBinder
+import com.rosan.dhizuku.data.account.entity.AccountAuthenticatorEntity
+import com.rosan.dhizuku.data.account.entity.AccountEntity
+import com.rosan.dhizuku.data.account.entity.UserEntity
+import com.rosan.dhizuku.data.account.repo.UserService
+import rikka.shizuku.Shizuku
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class ShizukuUserService(private val context: Context) : UserService {
+    // 本地包管理器：仅传入包名字符串读取资源，不接收远程ApplicationInfo
+    private val basePackageManager by lazy { context.packageManager }
+    // Shizuku远程Binder服务
+    private val userManager by lazy { IUserManager.Stub.asInterface(shizukuBinder(Context.USER_SERVICE)) }
+    private val accountManager by lazy { IAccountManager.Stub.asInterface(shizukuBinder(Context.ACCOUNT_SERVICE)) }
+    private val packageManager by lazy { IPackageManager.Stub.asInterface(shizukuBinder("package")) }
+
+    private fun writeLog(message: String) {
+        try {
+            val dir = context.getExternalFilesDir(null)
+            if (dir != null) {
+                val logFile = File(dir, "log.txt")
+                val time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault()).format(Date())
+                logFile.appendText("[$time] $message\n")
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override suspend fun removeUser(user: UserEntity): Boolean = removeUser(user.id)
+
+    override suspend fun removeUser(userId: Int): Boolean = userManager.removeUser(userId)
+
+    override suspend fun getUsers(): List<UserEntity> = requireShizukuPermissionGranted(context) {
+        (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+            userManager.getUsers(false, false, false)
+        else userManager.getUsers(false)).map {
+            UserEntity(id = it.id, name = it.name)
+        }
+    }
+
+    override suspend fun getAccountAuthenticators(userId: Int): List<AccountAuthenticatorEntity> =
+        requireShizukuPermissionGranted(context) {
+            val flags = 0x00000200L // PackageManager.MATCH_DISABLED_COMPONENTS
+            accountManager.getAuthenticatorTypes(userId).mapNotNull { description ->
+                try {
+                    val packageName = description.packageName
+                    // 远程仅获取PackageInfo，不使用内部ApplicationInfo
+                    val packageInfo: PackageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                        packageManager.getPackageInfo(packageName, flags, userId)
+                    else packageManager.getPackageInfo(packageName, flags.toInt(), userId)
+
+                    // 本地PackageManager通过【包名字符串】读取资源，不传递远程ApplicationInfo
+                    val appLabel = basePackageManager.getApplicationLabel(basePackageManager.getApplicationInfo(packageName, 0)).toString()
+                    val descLabel = basePackageManager.getText(packageName, description.labelId, null).toString()
+                    val label = if (appLabel == descLabel) appLabel else "$appLabel - $descLabel"
+                    val icon = basePackageManager.getApplicationIcon(packageName)
+
+                    AccountAuthenticatorEntity(
+                        userId = userId,
+                        type = description.type,
+                        packageName = description.packageName,
+                        label = label,
+                        icon = icon
+                    )
+                } catch (e: RemoteException) {
+                    writeLog("getAccountAuthenticators RemoteException for ${description.packageName}: ${e.message}")
+                    null
+                } catch (e: Exception) {
+                    writeLog("getAccountAuthenticators exception for ${description.packageName}: ${e.message}")
+                    null
+                }
+            }
+        }
+
+    override suspend fun getAccounts(userId: Int): List<AccountEntity> =
+        requireShizukuPermissionGranted(context) {
+            val dumpAccounts = getAccountsByDump(userId)
+            val managerAccounts = try {
+                getAccountsByManager(userId)
+            } catch (e: Exception) {
+                emptyList()
+            }
+
+            val managerGrouped = managerAccounts.groupBy { it.type }.mapValues { it.value.toMutableList() }
+
+            dumpAccounts.map { dumpAccount ->
+                val managerList = managerGrouped[dumpAccount.type]
+                if (managerList != null && managerList.isNotEmpty()) {
+                    val managerAccount = managerList.removeAt(0)
+                    dumpAccount.copy(name = managerAccount.name)
+                } else {
+                    dumpAccount
+                }
+            }
+        }
+
+    private fun getAccountsByManager(userId: Int): List<AccountEntity> {
+        return (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val callingPackage = try {
+                basePackageManager.getPackagesForUid(Shizuku.getUid())?.firstOrNull() ?: "android"
+            } catch (e: Exception) {
+                "android"
+            }
+            accountManager.getAccountsAsUser(null, userId, callingPackage)
+        } else accountManager.getAccountsAsUser(null, userId)).map {
+            AccountEntity(
+                userId = userId,
+                type = it.type,
+                name = it.name
+            )
+        }
+    }
+
+    private fun getAccountsByDump(userId: Int): List<AccountEntity> {
+        val text = accountManager.asBinder().dumpText()
+        val lines = text.lines()
+
+        val userStartRegex = """^\s*User UserInfo\{(\d+)[:\}].*""".toRegex()
+        var inUserBlock = false
+        val userLines = mutableListOf<String>()
+
+        for (line in lines) {
+            val match = userStartRegex.matchEntire(line)
+            if (match != null) {
+                val currentUserId = match.groupValues[1].toInt()
+                if (currentUserId == userId) {
+                    inUserBlock = true
+                    continue
+                } else if (inUserBlock) {
+                    break
+                }
+            }
+            if (inUserBlock) {
+                if (line.isNotEmpty() && !line.first().isWhitespace()) {
+                    break
+                }
+                userLines.add(line)
+            }
+        }
+
+        val accountLines = mutableListOf<String>()
+        var foundAccountsSection = false
+        for (line in userLines) {
+            val trimmed = line.trim()
+            if (trimmed.startsWith("Accounts:")) {
+                foundAccountsSection = true
+                continue
+            }
+            if (foundAccountsSection) {
+                if (line.isEmpty()) continue
+                val leadingSpaces = line.length - line.trimStart().length
+                if (leadingSpaces <= 2) {
+                    break
+                }
+                accountLines.add(line)
+            }
+        }
+
+        val accountsText = accountLines.joinToString("\n")
+        val accountRegex = """Account\s*\{\s*name=(.*?), type=(.*?)[,}]""".toRegex()
+
+        return accountRegex.findAll(accountsText)
+            .map {
+                val name = it.groupValues[1]
+                val type = it.groupValues[2]
+
+                AccountEntity(
+                    userId = userId,
+                    type = type,
+                    name = name
+                )
+            }
+            .toList()
+    }
+
+    override suspend fun removeAccount(account: AccountEntity): Boolean = requireShizukuPermissionGranted(context) {
+        val targetAccount = Account(account.name, account.type)
+        val result = suspendCancellableCoroutine<Boolean> { continuation ->
+            val response = object : IAccountManagerResponse.Stub() {
+                override fun onResult(value: Bundle?) {
+                    val intent = value?.getParcelableCompat<android.content.Intent>("intent")
+                    if (intent != null) {
+                        try {
+                            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
+                    val success = value?.getBoolean("booleanResult", false) ?: false
+                    if (continuation.isActive) {
+                        continuation.resume(success)
+                    }
+                }
+
+                override fun onError(errorCode: Int, errorMessage: String?) {
+                    if (continuation.isActive) {
+                        continuation.resume(false)
+                    }
+                }
+            }
+            try {
+                accountManager.removeAccountAsUser(response, targetAccount, false, account.userId)
+            } catch (e: Exception) {
+                if (continuation.isActive) {
+                    continuation.resumeWith(Result.failure(e))
+                }
+            }
+        }
+        result
+    }
+
+    override suspend fun setPackageEnabled(packageName: String, enabled: Boolean, userId: Int): Boolean = requireShizukuPermissionGranted(context) {
+        val newState = if (enabled) 1 else 3
+        val callingPackage = when (Shizuku.getUid()) {
+            0 -> "android"
+            2000 -> "com.android.shell"
+            else -> try {
+                basePackageManager.getPackagesForUid(Shizuku.getUid())?.firstOrNull() ?: "android"
+            } catch (e: Exception) {
+                "android"
+            }
+        }
+        writeLog("setPackageEnabled: pkg=$packageName enabled=$enabled state=$newState callingPkg=$callingPackage userId=$userId")
+        try {
+            packageManager.setApplicationEnabledSetting(packageName, newState, 0, userId, callingPackage)
+            writeLog("setApplicationEnabledSetting success for $packageName")
+            true
+        } catch (e: Exception) {
+            writeLog("setApplicationEnabledSetting error: ${e.message}")
+            throw e
+        }
+    }
+
+    override suspend fun isPackageEnabled(packageName: String, userId: Int): Boolean = requireShizukuPermissionGranted(context) {
+        try {
+            val flags = 0x00000200L
+            val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(packageName, flags, userId)
+            } else {
+                packageManager.getPackageInfo(packageName, flags.toInt(), userId)
+            }
+            val enabledState = info?.applicationInfo?.enabled ?: true
+            writeLog("isPackageEnabled of $packageName: $enabledState")
+            enabledState
+        } catch (e: Exception) {
+            writeLog("isPackageEnabled exception of $packageName: ${e.message}")
+            e.printStackTrace()
+            true
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/data/account/repo/UserService.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/account/repo/UserService.kt
@@ -1,0 +1,23 @@
+package com.rosan.dhizuku.data.account.repo
+
+import com.rosan.dhizuku.data.account.entity.AccountAuthenticatorEntity
+import com.rosan.dhizuku.data.account.entity.AccountEntity
+import com.rosan.dhizuku.data.account.entity.UserEntity
+
+interface UserService {
+    suspend fun removeUser(user: UserEntity): Boolean
+
+    suspend fun removeUser(userId: Int): Boolean
+
+    suspend fun getUsers(): List<UserEntity>
+
+    suspend fun getAccountAuthenticators(userId: Int): List<AccountAuthenticatorEntity>
+
+    suspend fun getAccounts(userId: Int): List<AccountEntity>
+
+    suspend fun removeAccount(account: AccountEntity): Boolean
+
+    suspend fun setPackageEnabled(packageName: String, enabled: Boolean, userId: Int): Boolean
+
+    suspend fun isPackageEnabled(packageName: String, userId: Int): Boolean
+}

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/BinderUtil.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/BinderUtil.kt
@@ -1,0 +1,36 @@
+package com.rosan.dhizuku.data.common.util
+
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
+import android.os.ParcelFileDescriptor
+import java.io.FileDescriptor
+
+fun IBinder.transactDump(fd: FileDescriptor, args: Array<String>? = null) {
+    val data = Parcel.obtain()
+    val reply = Parcel.obtain()
+    try {
+        data.writeFileDescriptor(fd)
+        data.writeStringArray(args)
+        transact(Binder.DUMP_TRANSACTION, data, reply, 0)
+        reply.readException()
+    } finally {
+        data.recycle()
+        reply.recycle()
+    }
+}
+
+fun IBinder.dumpBytes(args: Array<String>? = null): ByteArray {
+    val pipe = ParcelFileDescriptor.createPipe()
+    val readFD = pipe[0]
+    val writeFD = pipe[1]
+    writeFD.use {
+        transactDump(it.fileDescriptor, args)
+    }
+    return readFD.use {
+        ParcelFileDescriptor.AutoCloseInputStream(it).readBytes()
+    }
+}
+
+fun IBinder.dumpText(args: Array<String>? = null): String =
+    dumpBytes(args).decodeToString()

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/BundleCompat.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/BundleCompat.kt
@@ -1,0 +1,14 @@
+package com.rosan.dhizuku.data.common.util
+
+import android.os.Build
+import android.os.Bundle
+import android.os.Parcelable
+
+@Suppress("DEPRECATION")
+inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getParcelable(key, T::class.java)
+    } else {
+        getParcelable(key) as? T
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/CauseUtil.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/CauseUtil.kt
@@ -1,0 +1,10 @@
+package com.rosan.dhizuku.data.common.util
+
+import com.rosan.dhizuku.data.common.model.exception.ShizukuNotWorkException
+
+fun Throwable.help(): String? {
+    return when (this) {
+        is ShizukuNotWorkException -> "请激活 Shizuku 并同意权限请求"
+        else -> null
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/ContextUtil.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/ContextUtil.kt
@@ -1,6 +1,8 @@
 package com.rosan.dhizuku.data.common.util
 
 import android.content.Context
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
@@ -13,6 +15,13 @@ fun Context.openUrlInBrowser(url: String) {
     val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     startActivity(intent)
+}
+
+fun Context.copy(text: CharSequence) {
+    Handler(Looper.getMainLooper()).post {
+        val manager = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        manager.setPrimaryClip(ClipData.newPlainText("Label", text))
+    }
 }
 
 fun Context.toast(text: CharSequence, duration: Int = Toast.LENGTH_SHORT) {

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/MapsUtil.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/MapsUtil.kt
@@ -1,0 +1,7 @@
+package com.rosan.dhizuku.data.common.util
+
+inline fun <K, V> MutableMap<K, V>.replace(key: K, action: (value: V?) -> V): V {
+    val newValue = this[key].let(action)
+    this[key] = newValue
+    return newValue
+}

--- a/app/src/main/java/com/rosan/dhizuku/data/common/util/ShizukuUtil.kt
+++ b/app/src/main/java/com/rosan/dhizuku/data/common/util/ShizukuUtil.kt
@@ -1,6 +1,9 @@
 package com.rosan.dhizuku.data.common.util
 
 import android.content.pm.PackageManager
+import android.content.Context
+import android.os.IBinder
+import android.os.ServiceManager
 
 import com.rosan.dhizuku.data.common.model.exception.ShizukuNotWorkException
 import com.rosan.dhizuku.shared.DhizukuVariables
@@ -11,6 +14,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 
 import rikka.shizuku.Shizuku
+import rikka.shizuku.ShizukuBinderWrapper
 import rikka.sui.Sui
 
 private suspend fun blockingRequestShizukuPermission() = callbackFlow {
@@ -38,6 +42,21 @@ suspend fun <T> requireShizukuPermissionGranted(action: suspend () -> T): T {
         blockingRequestShizukuPermission()
     return action()
 }
+
+suspend fun <T> requireShizukuPermissionGranted(context: Context, action: suspend () -> T): T {
+    Sui.init(context.packageName)
+    val binder = Shizuku.getBinder()
+    if (binder == null || !binder.pingBinder())
+        throw ShizukuNotWorkException("sui/shizuku isn't activated")
+    if (Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED)
+        blockingRequestShizukuPermission()
+    return action()
+}
+
+fun shizukuBinder(name: String): IBinder =
+    shizukuBinder(ServiceManager.getService(name))
+
+fun shizukuBinder(binder: IBinder): IBinder = ShizukuBinderWrapper(binder)
 
 fun checkShizukuWorked(): Boolean {
     val sui: Boolean = Sui.init(DhizukuVariables.OFFICIAL_PACKAGE_NAME)

--- a/app/src/main/java/com/rosan/dhizuku/di/data_module.kt
+++ b/app/src/main/java/com/rosan/dhizuku/di/data_module.kt
@@ -1,5 +1,7 @@
 package com.rosan.dhizuku.di
 
+import com.rosan.dhizuku.data.account.model.ShizukuUserService
+import com.rosan.dhizuku.data.account.repo.UserService
 import com.rosan.dhizuku.data.settings.model.preferences.impl.SettingsRepoImpl
 import com.rosan.dhizuku.data.settings.model.room.DhizukuRoom
 import com.rosan.dhizuku.data.settings.model.room.impl.AppRepoImpl
@@ -7,6 +9,7 @@ import com.rosan.dhizuku.data.settings.repo.AppRepo
 import com.rosan.dhizuku.data.settings.repo.SettingsRepo
 
 import org.koin.dsl.module
+import org.koin.android.ext.koin.androidContext
 
 val dataModule = module {
     single {
@@ -20,5 +23,9 @@ val dataModule = module {
 
     single<SettingsRepo> {
         SettingsRepoImpl()
+    }
+
+    single<UserService> {
+        ShizukuUserService(androidContext())
     }
 }

--- a/app/src/main/java/com/rosan/dhizuku/di/viewmodel_module.kt
+++ b/app/src/main/java/com/rosan/dhizuku/di/viewmodel_module.kt
@@ -2,7 +2,9 @@ package com.rosan.dhizuku.di
 
 import com.rosan.dhizuku.ui.page.settings.activate.ActivateViewModel
 import com.rosan.dhizuku.ui.page.settings.app_management.AppManagementViewModel
+import com.rosan.dhizuku.ui.page.settings.account_manager.AccountManagerViewModel
 import com.rosan.dhizuku.ui.page.settings.settings.SettingsViewModel
+import com.rosan.dhizuku.ui.page.settings.user_manager.UserManagerViewModel
 
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -16,5 +18,11 @@ val viewModelModule = module {
     }
     viewModel {
         SettingsViewModel()
+    }
+    viewModel {
+        UserManagerViewModel()
+    }
+    viewModel { parameters ->
+        AccountManagerViewModel(parameters.get())
     }
 }

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/SettingsPage.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/SettingsPage.kt
@@ -1,15 +1,23 @@
 package com.rosan.dhizuku.ui.page.settings
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 
 import com.rosan.dhizuku.ui.page.settings.activate.ActivatePage
+import com.rosan.dhizuku.ui.page.settings.account_manager.AccountManagerPage
 import com.rosan.dhizuku.ui.page.settings.app_management.AppManagementPage
 import com.rosan.dhizuku.ui.page.settings.home.HomePage
 import com.rosan.dhizuku.ui.page.settings.settings.SettingsPage
+import com.rosan.dhizuku.ui.page.settings.user_manager.UserManagerPage
 
 @Composable
 fun SettingsPage(windowInsets: WindowInsets) {
@@ -18,6 +26,30 @@ fun SettingsPage(windowInsets: WindowInsets) {
     NavHost(
         navController = navController,
         startDestination = SettingsRoute.Home.route,
+        enterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        exitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        },
+        popEnterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(300)
+            ) + fadeIn(animationSpec = tween(300))
+        },
+        popExitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(300)
+            ) + fadeOut(animationSpec = tween(300))
+        }
     ) {
         composable(route = SettingsRoute.Home.route) {
             HomePage(
@@ -29,6 +61,34 @@ fun SettingsPage(windowInsets: WindowInsets) {
             AppManagementPage(
                 windowInsets = windowInsets,
                 navController = navController
+            )
+        }
+        composable(route = SettingsRoute.UserManagement.route) {
+            UserManagerPage(
+                windowInsets = windowInsets,
+                onNavigateToAccount = { userId ->
+                    navController.navigate(SettingsRoute.AccountManagement.route(userId))
+                },
+                onBack = navController::navigateUp
+            )
+        }
+        composable(
+            route = SettingsRoute.AccountManagement.route,
+            arguments = listOf(
+                navArgument("id") {
+                    type = NavType.IntType
+                }
+            )
+        ) {
+            val userId = it.arguments?.getInt("id")
+            if (userId == null) {
+                navController.navigateUp()
+                return@composable
+            }
+            AccountManagerPage(
+                windowInsets = windowInsets,
+                userId = userId,
+                onBack = navController::navigateUp
             )
         }
         composable(route = SettingsRoute.Settings.route) {

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/SettingsRoute.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/SettingsRoute.kt
@@ -3,6 +3,10 @@ package com.rosan.dhizuku.ui.page.settings
 sealed class SettingsRoute(val route: String) {
     data object Home : SettingsRoute("home")
     data object AppManagement : SettingsRoute("app_management")
+    data object UserManagement : SettingsRoute("user_management")
+    data object AccountManagement : SettingsRoute("account_management/{id}") {
+        fun route(userId: Int) = "account_management/$userId"
+    }
     data object Settings : SettingsRoute("settings")
     data object Activate : SettingsRoute("activate/{mode}") {
         enum class Mode {

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerPage.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerPage.kt
@@ -1,0 +1,192 @@
+package com.rosan.dhizuku.ui.page.settings.account_manager
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Lock
+import androidx.compose.material.icons.twotone.LockOpen
+import androidx.compose.material.icons.twotone.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.ui.Alignment
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rosan.dhizuku.R
+import com.rosan.dhizuku.data.common.util.copy
+import com.rosan.dhizuku.data.common.util.toast
+import com.rosan.dhizuku.ui.page.settings.account_manager.components.AppCard
+import com.rosan.dhizuku.ui.widget.EmptyState
+import com.rosan.dhizuku.ui.theme.exclude
+import org.json.JSONArray
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalFoundationApi::class
+)
+@Composable
+fun AccountManagerPage(
+    windowInsets: WindowInsets,
+    userId: Int,
+    onBack: () -> Unit,
+    viewModel: AccountManagerViewModel = koinViewModel(parameters = { parametersOf(userId) })
+) {
+    LaunchedEffect(userId) {
+        viewModel.dispatch(AccountManagerViewAction.Load)
+    }
+    val context = LocalContext.current
+
+    Scaffold(
+        modifier = Modifier
+            .windowInsetsPadding(windowInsets.exclude(WindowInsetsSides.Bottom))
+            .fillMaxSize(),
+        contentWindowInsets = windowInsets.only(WindowInsetsSides.Bottom),
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                },
+                title = { Text(stringResource(R.string.account_manager)) },
+                actions = {
+                    IconButton(onClick = {
+                        try {
+                            val intent = android.content.Intent(android.provider.Settings.ACTION_SYNC_SETTINGS)
+                            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            context.toast(R.string.error_open_sync_settings)
+                        }
+                    }) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Settings,
+                            contentDescription = stringResource(R.string.action_open_sync_settings)
+                        )
+                    }
+                    val isTogglingAll = viewModel.togglingPackages.isNotEmpty()
+                    if (isTogglingAll) {
+                        Box(
+                            modifier = Modifier.padding(12.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    } else {
+                        val allFrozen = viewModel.state.authenticators.isNotEmpty() &&
+                                viewModel.state.authenticators.all { it.isFrozen }
+                        IconButton(onClick = {
+                            viewModel.dispatch(
+                                if (allFrozen) AccountManagerViewAction.UnfreezeAll
+                                else AccountManagerViewAction.FreezeAll
+                            )
+                        }) {
+                            Icon(
+                                imageVector = if (allFrozen) Icons.TwoTone.Lock else Icons.TwoTone.LockOpen,
+                                contentDescription = stringResource(
+                                    if (allFrozen) R.string.action_unfreeze_all
+                                    else R.string.action_freeze_all
+                                )
+                            )
+                        }
+                    }
+                }
+            )
+        },
+    ) { innerPadding ->
+        val pullToRefreshState = rememberPullToRefreshState()
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .pullToRefresh(
+                    state = pullToRefreshState,
+                    isRefreshing = viewModel.state.loading,
+                    onRefresh = {
+                        viewModel.dispatch(AccountManagerViewAction.Load)
+                    }
+                )
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                if (viewModel.state.authenticators.isEmpty()) {
+                    item("empty_state") {
+                        Box(
+                            modifier = Modifier
+                                .fillParentMaxSize()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            EmptyState(message = stringResource(R.string.account_empty))
+                        }
+                    }
+                } else {
+                    items(
+                        items = viewModel.state.authenticators,
+                        key = { "${it.auth.packageName}_${it.auth.userId}_${it.auth.type}" },
+                        contentType = { if (it.isFrozen) "frozen" else "active" }
+                    ) { authenticator ->
+                        AppCard(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItem(),
+                            authenticator = authenticator,
+                            isToggling = viewModel.togglingPackages.contains(authenticator.auth.packageName),
+                            onFreezeToggle = { packageName, isFrozen ->
+                                viewModel.dispatch(
+                                    AccountManagerViewAction.FreezeToggle(packageName, isFrozen)
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            PullToRefreshDefaults.Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                state = pullToRefreshState,
+                isRefreshing = viewModel.state.loading
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewAction.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewAction.kt
@@ -1,0 +1,8 @@
+package com.rosan.dhizuku.ui.page.settings.account_manager
+
+sealed class AccountManagerViewAction {
+    object Load : AccountManagerViewAction()
+    data class FreezeToggle(val packageName: String, val currentFrozen: Boolean) : AccountManagerViewAction()
+    object FreezeAll : AccountManagerViewAction()
+    object UnfreezeAll : AccountManagerViewAction()
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewModel.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewModel.kt
@@ -1,0 +1,325 @@
+package com.rosan.dhizuku.ui.page.settings.account_manager
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rosan.dhizuku.data.common.util.replace
+import com.rosan.dhizuku.data.common.util.toast
+import com.rosan.dhizuku.data.account.repo.UserService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class AccountManagerViewModel(
+    private val userId: Int
+) : ViewModel(), KoinComponent {
+    private val jobs = mutableMapOf<String, Job>()
+
+    private val context by inject<Context>()
+    private val userService by inject<UserService>()
+
+    // SharedPreferences to persist frozen packages across app restarts
+    private val prefs: SharedPreferences by lazy {
+        context.getSharedPreferences("frozen_packages_user_$userId", Context.MODE_PRIVATE)
+    }
+
+    data class FrozenInfo(
+        val packageName: String,
+        val type: String,
+        val label: String
+    )
+
+    private fun getFrozenPackages(): List<FrozenInfo> = synchronized(prefs) {
+        val set = prefs.getStringSet("frozen_info", emptySet()) ?: emptySet()
+        set.mapNotNull {
+            val parts = it.split("|", limit = 3)
+            if (parts.size >= 3) {
+                FrozenInfo(packageName = parts[0], type = parts[1], label = parts[2])
+            } else null
+        }
+    }
+
+    private fun saveFrozenPackage(packageName: String, type: String, label: String) = synchronized(prefs) {
+        val current = prefs.getStringSet("frozen_info", emptySet())?.toMutableSet() ?: mutableSetOf()
+        current.removeAll { it.startsWith("$packageName|") }
+        current.add("$packageName|$type|$label")
+        prefs.edit().putStringSet("frozen_info", current).commit()
+    }
+
+    private fun removeFrozenPackage(packageName: String) = synchronized(prefs) {
+        val current = prefs.getStringSet("frozen_info", emptySet())?.toMutableSet() ?: mutableSetOf()
+        current.removeAll { it.startsWith("$packageName|") }
+        prefs.edit().putStringSet("frozen_info", current).commit()
+    }
+
+    var state by mutableStateOf(AccountManagerViewState())
+        private set
+
+    var togglingPackages by mutableStateOf(emptySet<String>())
+        private set
+
+    fun dispatch(action: AccountManagerViewAction) {
+        when (action) {
+            AccountManagerViewAction.Load -> load()
+            is AccountManagerViewAction.FreezeToggle -> freezeToggle(action.packageName, action.currentFrozen)
+            AccountManagerViewAction.FreezeAll -> freezeAll()
+            AccountManagerViewAction.UnfreezeAll -> unfreezeAll()
+        }
+    }
+
+    private fun freezeAll() {
+        val toFreeze = state.authenticators.filter { !it.isFrozen }
+        if (toFreeze.isEmpty()) return
+
+        val pkgNames = toFreeze.map { it.auth.packageName }
+        togglingPackages = togglingPackages + pkgNames
+
+        val updated = state.authenticators.map {
+            if (pkgNames.contains(it.auth.packageName)) it.copy(isFrozen = true) else it
+        }
+        state = state.copy(authenticators = updated)
+
+        jobs.replace("freeze_all") { old ->
+            old?.cancel()
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    toFreeze.forEach { item ->
+                        val pkg = item.auth.packageName
+                        val type = item.auth.type
+                        val label = item.auth.label
+                        try {
+                            userService.setPackageEnabled(pkg, false, userId)
+                            saveFrozenPackage(pkg, type, label)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
+                    delay(800)
+                    load(showLoading = false)
+                } finally {
+                    withContext(Dispatchers.Main) {
+                        togglingPackages = togglingPackages - pkgNames.toSet()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun unfreezeAll() {
+        val toThaw = state.authenticators.filter { it.isFrozen }
+        if (toThaw.isEmpty()) return
+
+        val pkgNames = toThaw.map { it.auth.packageName }
+        togglingPackages = togglingPackages + pkgNames
+
+        val updated = state.authenticators.map {
+            if (pkgNames.contains(it.auth.packageName)) it.copy(isFrozen = false) else it
+        }
+        state = state.copy(authenticators = updated)
+
+        jobs.replace("unfreeze_all") { old ->
+            old?.cancel()
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    toThaw.forEach { item ->
+                        val pkg = item.auth.packageName
+                        try {
+                            userService.setPackageEnabled(pkg, true, userId)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
+                    delay(800)
+                    load(showLoading = false)
+                } finally {
+                    withContext(Dispatchers.Main) {
+                        togglingPackages = togglingPackages - pkgNames.toSet()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun freezeToggle(packageName: String, currentFrozen: Boolean) {
+        if (togglingPackages.contains(packageName)) return
+
+        togglingPackages = togglingPackages + packageName
+
+        // Optimistic UI update
+        val updatedAuthenticators = state.authenticators.map {
+            if (it.auth.packageName == packageName) it.copy(isFrozen = !currentFrozen) else it
+        }
+        state = state.copy(authenticators = updatedAuthenticators)
+
+        val existing = state.authenticators.find { it.auth.packageName == packageName }
+        val type = existing?.auth?.type ?: ""
+        val label = existing?.auth?.label ?: ""
+
+        jobs.replace("toggle_$packageName") { oldJob ->
+            oldJob?.cancel()
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    userService.setPackageEnabled(packageName, currentFrozen, userId)
+                    // Persist new frozen state
+                    if (!currentFrozen) saveFrozenPackage(packageName, type, label)
+                    delay(800)
+                    load(showLoading = false)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    withContext(Dispatchers.Main) {
+                        context.toast("操作失败: ${e.localizedMessage ?: e.message}")
+                    }
+                    load(showLoading = false)
+                } finally {
+                    withContext(Dispatchers.Main) {
+                        togglingPackages = togglingPackages - packageName
+                    }
+                }
+            }
+        }
+    }
+
+    private fun load(showLoading: Boolean = true) {
+        jobs.replace("load") {
+            it?.cancel()
+            if (showLoading) {
+                state = state.copy(loading = true)
+            }
+            viewModelScope.launch(Dispatchers.IO) {
+                val frozenPackages = getFrozenPackages()
+                val auths = userService.getAccountAuthenticators(userId)
+                val accounts = userService.getAccounts(userId)
+
+                // Build authenticator list: active ones + any frozen ones not returned by system
+                val activeAuthMap = auths.associateBy { it.packageName }
+
+                // Merge: active authenticators + frozen ones that disappeared from system list
+                val allAuthenticators = mutableListOf<AccountManagerViewState.Authenticator>()
+
+                // Build a set of package names that we think are frozen based on SharedPreferences
+                val frozenPkgNames = frozenPackages.map { it.packageName }.toSet()
+
+                // Add all active authenticators (only those with accounts, or that are frozen)
+                auths.forEach { auth ->
+                    val matchingAccounts = accounts.filter { auth.type == it.type }
+                    
+                    var isActuallyFrozen = frozenPkgNames.contains(auth.packageName)
+                    if (togglingPackages.contains(auth.packageName)) {
+                        val existing = state.authenticators.find { it.auth.packageName == auth.packageName }
+                        if (existing != null) {
+                            isActuallyFrozen = existing.isFrozen
+                        }
+                    } else if (isActuallyFrozen) {
+                        try {
+                            val isSystemFrozen = !userService.isPackageEnabled(auth.packageName, userId)
+                            if (!isSystemFrozen) {
+                                isActuallyFrozen = false
+                                removeFrozenPackage(auth.packageName)
+                            }
+                        } catch (e: Exception) {
+                            isActuallyFrozen = false
+                            removeFrozenPackage(auth.packageName)
+                        }
+                    }
+
+                    // Only show if it has accounts OR is frozen (frozen apps lose their accounts)
+                    if (matchingAccounts.isNotEmpty() || isActuallyFrozen) {
+                        allAuthenticators.add(
+                            AccountManagerViewState.Authenticator(
+                                auth = auth,
+                                accounts = matchingAccounts,
+                                isFrozen = isActuallyFrozen
+                            )
+                        )
+                    }
+                }
+
+                // Add frozen packages not currently returned by getAccountAuthenticators
+                // (because system hides disabled app's authenticators)
+                frozenPackages
+                    .filter { activeAuthMap[it.packageName] == null }
+                    .forEach { info ->
+                        try {
+                            var isStillFrozen = !userService.isPackageEnabled(info.packageName, userId)
+                            if (togglingPackages.contains(info.packageName)) {
+                                val existing = state.authenticators.find { it.auth.packageName == info.packageName }
+                                if (existing != null) {
+                                    isStillFrozen = existing.isFrozen
+                                }
+                            }
+
+                            if (isStillFrozen) {
+                                val existing = state.authenticators.find { it.auth.packageName == info.packageName }
+                                if (existing != null) {
+                                    allAuthenticators.add(existing.copy(isFrozen = true, accounts = emptyList()))
+                                } else {
+                                    // Load the icon dynamically since the package is disabled
+                                    val icon = try {
+                                        context.packageManager.getApplicationIcon(info.packageName)
+                                    } catch (e: Exception) {
+                                        androidx.core.content.ContextCompat.getDrawable(
+                                            context,
+                                            android.R.drawable.sym_def_app_icon
+                                        )!!
+                                    }
+                                    val placeholderAuth = com.rosan.dhizuku.data.account.entity.AccountAuthenticatorEntity(
+                                        userId = userId,
+                                        type = info.type,
+                                        packageName = info.packageName,
+                                        label = info.label,
+                                        icon = icon
+                                    )
+                                    allAuthenticators.add(
+                                        AccountManagerViewState.Authenticator(
+                                            auth = placeholderAuth,
+                                            accounts = emptyList(),
+                                            isFrozen = true
+                                        )
+                                    )
+                                }
+                            } else {
+                                // Thawed but not in auths yet. Display it as active placeholder so it doesn't disappear!
+                                val existing = state.authenticators.find { it.auth.packageName == info.packageName }
+                                val icon = existing?.auth?.icon ?: try {
+                                    context.packageManager.getApplicationIcon(info.packageName)
+                                } catch (e: Exception) {
+                                    androidx.core.content.ContextCompat.getDrawable(
+                                        context,
+                                        android.R.drawable.sym_def_app_icon
+                                    )!!
+                                }
+                                val placeholderAuth = com.rosan.dhizuku.data.account.entity.AccountAuthenticatorEntity(
+                                    userId = userId,
+                                    type = info.type,
+                                    packageName = info.packageName,
+                                    label = info.label,
+                                    icon = icon
+                                )
+                                allAuthenticators.add(
+                                    AccountManagerViewState.Authenticator(
+                                        auth = placeholderAuth,
+                                        accounts = emptyList(),
+                                        isFrozen = false // Show as active (unfrozen)
+                                    )
+                                )
+                            }
+                        } catch (e: Exception) {
+                            if (!togglingPackages.contains(info.packageName)) {
+                                removeFrozenPackage(info.packageName)
+                            }
+                        }
+                    }
+
+                state = state.copy(authenticators = allAuthenticators.sortedBy { it.auth.label }, loading = false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewState.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/AccountManagerViewState.kt
@@ -1,0 +1,15 @@
+package com.rosan.dhizuku.ui.page.settings.account_manager
+
+import com.rosan.dhizuku.data.account.entity.AccountAuthenticatorEntity
+import com.rosan.dhizuku.data.account.entity.AccountEntity
+
+data class AccountManagerViewState(
+    val authenticators: List<Authenticator> = emptyList(),
+    val loading: Boolean = false
+) {
+    data class Authenticator(
+        val auth: AccountAuthenticatorEntity,
+        val accounts: List<AccountEntity>,
+        val isFrozen: Boolean = false
+    )
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/components/AppCard.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/account_manager/components/AppCard.kt
@@ -1,0 +1,129 @@
+package com.rosan.dhizuku.ui.page.settings.account_manager.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Lock
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rosan.dhizuku.R
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.runtime.getValue
+import com.rosan.dhizuku.ui.page.settings.account_manager.AccountManagerViewState
+import com.rosan.dhizuku.ui.theme.AppIconCache
+
+@Composable
+fun AppCard(
+    modifier: Modifier = Modifier,
+    authenticator: AccountManagerViewState.Authenticator,
+    isToggling: Boolean = false,
+    onFreezeToggle: (packageName: String, isFrozen: Boolean) -> Unit
+) {
+    val animatedAlpha by animateFloatAsState(
+        targetValue = if (authenticator.isFrozen) 0.6f else 1f,
+        label = "alpha"
+    )
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(animatedAlpha)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val imageBitmap = AppIconCache.rememberImageBitmapState(
+                packageName = authenticator.auth.packageName,
+                drawable = authenticator.auth.icon
+            )
+            Image(
+                bitmap = imageBitmap.value,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp)
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Text(
+                        text = authenticator.auth.label,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+
+                    AnimatedVisibility(
+                        visible = authenticator.isFrozen,
+                        enter = fadeIn() + scaleIn(),
+                        exit = fadeOut() + scaleOut()
+                    ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Lock,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                }
+                Text(
+                    text = authenticator.auth.packageName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+
+            TextButton(
+                onClick = { onFreezeToggle(authenticator.auth.packageName, authenticator.isFrozen) },
+                enabled = !isToggling,
+                colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                    contentColor = if (authenticator.isFrozen) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    }
+                )
+            ) {
+                if (isToggling) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = if (authenticator.isFrozen) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        }
+                    )
+                } else {
+                    Text(
+                        text = stringResource(
+                            if (authenticator.isFrozen) R.string.action_unfreeze
+                            else R.string.action_freeze
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/activate/ActivateViewModel.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/activate/ActivateViewModel.kt
@@ -176,13 +176,18 @@ class ActivateViewModel : ViewModel(), KoinComponent {
         requireShizukuPermissionGranted() {
             // wait for the account cache be refreshed
             delay(1500)
+            var success = false
             requireBinderWrapperDevicePolicyManager(wrapper = {
                 ShizukuBinderWrapper(it)
             }) {
                 val userId = Os.getuid() / 100000
                 it.setActiveAdmin(who, true, userId)
-                it.setDeviceOwner(who, null, userId)
+                success = it.setDeviceOwner(who, null, userId)
             }
+            if (!success) {
+                throw IllegalStateException("Failed to set Device Owner. Please make sure there are no accounts on the device.")
+            }
+            DhizukuState.sync(context)
         }
 
     @SuppressLint("PrivateApi")
@@ -190,13 +195,18 @@ class ActivateViewModel : ViewModel(), KoinComponent {
         requireShizukuPermissionGranted() {
             // wait for the account cache be refreshed
             delay(1500)
+            var success = false
             requireBinderWrapperDevicePolicyManager(wrapper = {
                 ShizukuBinderWrapper(it)
             }) {
                 val userId = Os.getuid() / 100000
                 it.setActiveAdmin(who, true, userId)
-                it.setProfileOwner(who, null, userId)
+                success = it.setProfileOwner(who, null, userId)
             }
+            if (!success) {
+                throw IllegalStateException("Failed to set Profile Owner. Please check your system configuration.")
+            }
+            DhizukuState.sync(context)
         }
 
     private fun DevicePolicyManager.setActiveAdmin(
@@ -217,48 +227,44 @@ class ActivateViewModel : ViewModel(), KoinComponent {
         who: ComponentName,
         ownerName: String?,
         userId: Int
-    ) {
+    ): Boolean {
         val clazz = this::class.java
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             clazz.getDeclaredMethod("setDeviceOwner", ComponentName::class.java, Int::class.java)
-                .also { it.isAccessible = true }.invoke(this, who, userId)
-            return
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                .also { it.isAccessible = true }.invoke(this, who, userId) as? Boolean ?: false
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             clazz.getDeclaredMethod(
                 "setDeviceOwner",
                 ComponentName::class.java,
                 String::class.java,
                 Int::class.java
-            ).also { it.isAccessible = true }.invoke(this, who, ownerName, userId)
-            return
+            ).also { it.isAccessible = true }.invoke(this, who, ownerName, userId) as? Boolean ?: false
+        } else {
+            clazz.getDeclaredMethod("setDeviceOwner", ComponentName::class.java, String::class.java)
+                .also { it.isAccessible = true }.invoke(this, who, ownerName) as? Boolean ?: false
         }
-        clazz.getDeclaredMethod("setDeviceOwner", ComponentName::class.java, String::class.java)
-            .also { it.isAccessible = true }.invoke(this, who, ownerName)
     }
 
     private fun DevicePolicyManager.setProfileOwner(
         who: ComponentName,
         ownerName: String?,
         userId: Int
-    ) {
+    ): Boolean {
         val clazz = this::class.java
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             clazz.getDeclaredMethod("setProfileOwner", ComponentName::class.java, Int::class.java)
-                .also { it.isAccessible = true }.invoke(this, who, userId)
-            return
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                .also { it.isAccessible = true }.invoke(this, who, userId) as? Boolean ?: false
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             clazz.getDeclaredMethod(
                 "setProfileOwner",
                 ComponentName::class.java,
                 String::class.java,
                 Int::class.java
-            ).also { it.isAccessible = true }.invoke(this, who, ownerName, userId)
-            return
+            ).also { it.isAccessible = true }.invoke(this, who, ownerName, userId) as? Boolean ?: false
+        } else {
+            clazz.getDeclaredMethod("setProfileOwner", ComponentName::class.java, String::class.java)
+                .also { it.isAccessible = true }.invoke(this, who, ownerName) as? Boolean ?: false
         }
-        clazz.getDeclaredMethod("setProfileOwner", ComponentName::class.java, String::class.java)
-            .also { it.isAccessible = true }.invoke(this, who, ownerName)
     }
 
     @SuppressLint("PrivateApi")

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/app_management/AppManagementPage.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/app_management/AppManagementPage.kt
@@ -47,8 +47,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.pullToRefresh
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -153,13 +155,21 @@ private fun LazyItemScope.ItemWidget(
     viewModel: AppManagementViewModel,
     data: AppManagementViewData
 ) {
+    val animatedCardColor by animateColorAsState(
+        targetValue = if (data.blocked) {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        label = "card_color"
+    )
     Card(
         modifier = Modifier
             .animateItem()
             .fillMaxWidth(),
-        colors = if (data.blocked) CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f)
-        ) else CardDefaults.cardColors(),
+        colors = CardDefaults.cardColors(
+            containerColor = animatedCardColor
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/home/HomePage.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/home/HomePage.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.twotone.SentimentVerySatisfied
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.SwapHorizontalCircle
 import androidx.compose.material.icons.twotone.Terminal
+import androidx.compose.material.icons.twotone.SupervisorAccount
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -140,6 +141,9 @@ fun HomePage(
             }
             if (dhizukuState.isOwner) item("app_management") {
                 AppManagementWidget(navController)
+            }
+            item("user_management") {
+                UserManagementWidget(navController)
             }
             if (dhizukuState.isOwner) item("dhizuku") {
                 DhizukuWidget(navController)
@@ -330,6 +334,19 @@ private fun LazyItemScope.AppManagementWidget(navController: NavController) {
         Text(stringResource(R.string.home_app_management_title))
     }, text = {
         Text(stringResource(R.string.home_app_management_dsp))
+    })
+}
+
+@Composable
+private fun LazyItemScope.UserManagementWidget(navController: NavController) {
+    CardWidget(onClick = {
+        navController.navigate(SettingsRoute.UserManagement.route)
+    }, icon = {
+        Icon(imageVector = Icons.TwoTone.SupervisorAccount, contentDescription = null)
+    }, title = {
+        Text(stringResource(R.string.user_manager))
+    }, text = {
+        Text(stringResource(R.string.home_user_management_dsp))
     })
 }
 

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerPage.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerPage.kt
@@ -1,0 +1,261 @@
+package com.rosan.dhizuku.ui.page.settings.user_manager
+
+import android.os.Process
+import androidx.compose.foundation.layout.size
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Warning
+import androidx.compose.material.icons.twotone.Person
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.rosan.dhizuku.R
+import com.rosan.dhizuku.data.common.util.help
+import com.rosan.dhizuku.data.account.entity.UserEntity
+import com.rosan.dhizuku.ui.widget.EmptyState
+import com.rosan.dhizuku.ui.theme.exclude
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalFoundationApi::class,
+    ExperimentalAnimationApi::class
+)
+@Composable
+fun UserManagerPage(
+    windowInsets: WindowInsets,
+    onNavigateToAccount: (userId: Int) -> Unit,
+    onBack: () -> Unit,
+    viewModel: UserManagerViewModel = koinViewModel()
+) {
+    LaunchedEffect(Unit) {
+        viewModel.dispatch(UserManagerViewAction.Load)
+    }
+
+    Scaffold(
+        modifier = Modifier
+            .windowInsetsPadding(windowInsets.exclude(WindowInsetsSides.Bottom))
+            .fillMaxSize(),
+        contentWindowInsets = windowInsets.only(WindowInsetsSides.Bottom),
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = null
+                        )
+                    }
+                },
+                title = { Text(stringResource(R.string.user_manager)) }
+            )
+        },
+    ) { innerPadding ->
+        val pullToRefreshState = rememberPullToRefreshState()
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .pullToRefresh(
+                    state = pullToRefreshState,
+                    isRefreshing = viewModel.state.loading,
+                    onRefresh = {
+                        viewModel.dispatch(UserManagerViewAction.Load)
+                    }
+                )
+        ) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                val cause = viewModel.state.cause
+                if (cause != null) {
+                    item("error_state") {
+                        val errorMsg = cause.help() ?: cause.localizedMessage ?: cause.toString()
+                        Box(
+                            modifier = Modifier
+                                .fillParentMaxSize()
+                                .padding(16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            EmptyState(message = errorMsg)
+                        }
+                    }
+                } else {
+                    items(viewModel.state.users, key = { it.id }) { user ->
+                        var alpha by remember { mutableStateOf(0f) }
+                        UserCard(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItem()
+                                .graphicsLayer(
+                                    alpha = animateFloatAsState(
+                                        targetValue = alpha,
+                                        animationSpec = spring(stiffness = 100f)
+                                    ).value
+                                ),
+                            viewModel = viewModel,
+                            onNavigateToAccount = { onNavigateToAccount(user.id) },
+                            user = user
+                        )
+                        SideEffect { alpha = 1f }
+                    }
+                }
+            }
+
+            PullToRefreshDefaults.Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                state = pullToRefreshState,
+                isRefreshing = viewModel.state.loading
+            )
+        }
+    }
+}
+
+@Composable
+private fun UserCard(
+    modifier: Modifier = Modifier,
+    viewModel: UserManagerViewModel,
+    onNavigateToAccount: (userId: Int) -> Unit,
+    user: UserEntity
+) {
+    var showing by remember { mutableStateOf(false) }
+
+    val curUserId = try {
+        val handle = Process.myUserHandle()
+        val method = handle.javaClass.getMethod("getIdentifier")
+        method.invoke(handle) as Int
+    } catch (_: Exception) { 0 }
+
+    ElevatedCard(
+        onClick = { onNavigateToAccount(user.id) },
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Person,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    user.name ?: stringResource(R.string.user_name_default),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    "ID: ${user.id}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+            if (curUserId == user.id) {
+                Text(
+                    text = stringResource(R.string.account_manager),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            } else {
+                IconButton(onClick = { showing = true }) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Delete,
+                        contentDescription = stringResource(R.string.remove),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+
+    if (curUserId != user.id) {
+        DeleteUserDialog(
+            viewModel = viewModel,
+            showing = showing,
+            onDismissRequest = { showing = false },
+            user = user
+        )
+    }
+}
+
+@Composable
+private fun DeleteUserDialog(
+    viewModel: UserManagerViewModel,
+    showing: Boolean,
+    onDismissRequest: () -> Unit,
+    user: UserEntity
+) {
+    if (!showing) return
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        icon = { Icon(imageVector = Icons.TwoTone.Warning, contentDescription = null) },
+        title = {
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(user.id.toString(), color = MaterialTheme.colorScheme.primary)
+                Text(user.name ?: stringResource(R.string.user_name_default))
+            }
+        },
+        text = { Text(stringResource(R.string.delete_user_warning)) },
+        confirmButton = {
+            TextButton(onClick = {
+                viewModel.dispatch(UserManagerViewAction.Remove(user))
+                onDismissRequest()
+            }) {
+                Text(stringResource(R.string.delete_user_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(R.string.delete_user_cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewAction.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewAction.kt
@@ -1,0 +1,9 @@
+package com.rosan.dhizuku.ui.page.settings.user_manager
+
+import com.rosan.dhizuku.data.account.entity.UserEntity
+
+sealed class UserManagerViewAction {
+    object Load : UserManagerViewAction()
+
+    data class Remove(val user: UserEntity) : UserManagerViewAction()
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewModel.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewModel.kt
@@ -1,0 +1,68 @@
+package com.rosan.dhizuku.ui.page.settings.user_manager
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rosan.dhizuku.data.common.util.replace
+import com.rosan.dhizuku.data.account.entity.UserEntity
+import com.rosan.dhizuku.data.account.repo.UserService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class UserManagerViewModel : ViewModel(), KoinComponent {
+    private val jobs = mutableMapOf<String, Job>()
+
+    private val userService by inject<UserService>()
+
+    var state by mutableStateOf(UserManagerViewState())
+        private set
+
+    fun dispatch(action: UserManagerViewAction) {
+        when (action) {
+            UserManagerViewAction.Load -> load()
+            is UserManagerViewAction.Remove -> remove(action.user)
+        }
+    }
+
+    private fun load() {
+        jobs.replace("load") {
+            it?.cancel()
+
+            viewModelScope.launch(Dispatchers.IO) {
+                var first = true
+                while (true) {
+                    if (first) {
+                        state = state.copy(loading = true)
+                    }
+                    kotlin.runCatching {
+                        userService.getUsers().sortedBy { it.id }
+                    }.onFailure {
+                        it.printStackTrace()
+                        state = state.copy(cause = it, loading = false)
+                    }.onSuccess {
+                        state = state.copy(users = it, cause = null, loading = false)
+                    }
+                    first = false
+                    delay(1500)
+                }
+            }
+        }
+    }
+
+    private fun remove(user: UserEntity) {
+        viewModelScope.launch {
+            val success = kotlin.runCatching {
+                userService.removeUser(user)
+            }.getOrDefault(false)
+            if (!success) {
+                state = state.copy(cause = RuntimeException("Failed to remove user ${user.name}"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewState.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/page/settings/user_manager/UserManagerViewState.kt
@@ -1,0 +1,9 @@
+package com.rosan.dhizuku.ui.page.settings.user_manager
+
+import com.rosan.dhizuku.data.account.entity.UserEntity
+
+data class UserManagerViewState(
+    val users: List<UserEntity> = emptyList(),
+    val cause: Throwable? = null,
+    val loading: Boolean = false
+)

--- a/app/src/main/java/com/rosan/dhizuku/ui/theme/AppIconCache.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/theme/AppIconCache.kt
@@ -78,4 +78,27 @@ object AppIconCache : KoinComponent {
 
         return state
     }
+
+    @Composable
+    fun rememberImageBitmapState(packageName: String, drawable: android.graphics.drawable.Drawable): MutableState<ImageBitmap> {
+        val key = packageName
+        val state = remember(key) { mutableStateOf(defaultImageBitMap) }
+
+        LaunchedEffect(key) {
+            val bitmap = withContext(Dispatchers.IO) {
+                lruCache[key] ?: try {
+                    drawable.toBitmap()
+                } catch (e: Exception) {
+                    null
+                }?.also {
+                    lruCache.put(key, it)
+                }
+            }
+            bitmap?.let {
+                state.value = it.asImageBitmap()
+            }
+        }
+
+        return state
+    }
 }

--- a/app/src/main/java/com/rosan/dhizuku/ui/widget/EmptyState.kt
+++ b/app/src/main/java/com/rosan/dhizuku/ui/widget/EmptyState.kt
@@ -1,0 +1,28 @@
+package com.rosan.dhizuku.ui.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun EmptyState(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home - Application Management -->
     <string name="home_app_management_title">应用管理</string>
     <string name="home_app_management_dsp">已申请或声明使用 Dhizuku 的应用将在此显示。</string>
+    <string name="home_user_management_dsp">管理系统用户及其账户。</string>
     <!-- Home - Shutdown -->
     <string name="home_shutdown_title">关闭</string>
     <string name="home_shutdown_dsp">除非 Dhizuku 自愿关闭，否则系统将无法关闭 Dhizuku。</string>
@@ -38,6 +39,21 @@
     <string name="permission_description">使用 Dhizuku 的 API</string>
     <string name="settings">设置</string>
     <string name="settings_desc">配置 Dhizuku 行为</string>
+    <string name="user_manager">用户管理</string>
+    <string name="user_name_default">未命名</string>
+    <string name="delete_user_warning">确定要删除此用户吗？\n所有处于此用户空间的应用和数据都会消失！！！</string>
+    <string name="delete_user_confirm">是的，我确定！</string>
+    <string name="delete_user_cancel">取消</string>
+    <string name="remove">移除</string>
+    <string name="account_manager">账号管理</string>
+    <string name="account_empty">没有账户存在</string>
+    <string name="copied_format_hail">复制成功，请在【雹】中导入！</string>
+    <string name="action_freeze">冷冻</string>
+    <string name="action_unfreeze">解冻</string>
+    <string name="action_open_sync_settings">打开同步设置</string>
+    <string name="action_freeze_all">一键冻结</string>
+    <string name="action_unfreeze_all">一键解冻</string>
+    <string name="error_open_sync_settings">无法打开系统账号设置界面</string>
     <string name="enable_dhizuku">启用 Dhizuku</string>
     <string name="enable_dhizuku_desc">允许其他应用使用 Dhizuku</string>
     <string name="whitelist_mode">白名单模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <!-- Home - Application Management -->
     <string name="home_app_management_title">Application Management</string>
     <string name="home_app_management_dsp">Apps that has requested or declared Dhizuku will show here.</string>
+    <string name="home_user_management_dsp">Manage users and their accounts.</string>
     <!-- Home - Dhizuku -->
     <string name="home_dhizuku_title">Activation by Dhizuku</string>
     <string name="home_dhizuku_dsp">If you have other Dhizuku implementations installed, you can switch between them at will. Please &lt;a href="%1$s"&gt;read the help&lt;/a&gt;.</string>
@@ -50,6 +51,21 @@
     <string name="service_running">Dhizuku is running</string>
     <string name="settings">Settings</string>
     <string name="settings_desc">Configure Dhizuku behavior</string>
+    <string name="user_manager">User Manager</string>
+    <string name="user_name_default">Untitled</string>
+    <string name="delete_user_warning">Are you sure you want to delete this user space?\nAll applications and data in this user space will be lost!!!</string>
+    <string name="delete_user_confirm">Yes, I\'m sure!</string>
+    <string name="delete_user_cancel">No</string>
+    <string name="remove">Remove</string>
+    <string name="account_manager">Account Manager</string>
+    <string name="account_empty">No account exists</string>
+    <string name="copied_format_hail">copied, import it in Hail!</string>
+    <string name="action_freeze">Freeze</string>
+    <string name="action_unfreeze">Unfreeze</string>
+    <string name="action_open_sync_settings">Open Sync Settings</string>
+    <string name="action_freeze_all">Freeze All</string>
+    <string name="action_unfreeze_all">Unfreeze All</string>
+    <string name="error_open_sync_settings">Cannot open system account settings</string>
     <string name="enable_dhizuku">Enable Dhizuku</string>
     <string name="enable_dhizuku_desc">Allow apps to use Dhizuku services</string>
     <string name="whitelist_mode">Whitelist Mode</string>

--- a/hidden-api/src/main/java/android/accounts/IAccountManager.java
+++ b/hidden-api/src/main/java/android/accounts/IAccountManager.java
@@ -1,0 +1,27 @@
+package android.accounts;
+
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.IInterface;
+
+import androidx.annotation.DeprecatedSinceApi;
+import androidx.annotation.RequiresApi;
+
+public interface IAccountManager extends IInterface {
+    AuthenticatorDescription[] getAuthenticatorTypes(int userId);
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    Account[] getAccountsAsUser(String accountType, int userId, String opPackageName);
+
+    @DeprecatedSinceApi(api = Build.VERSION_CODES.M)
+    Account[] getAccountsAsUser(String accountType, int userId);
+
+    void removeAccountAsUser(IAccountManagerResponse response, Account account, boolean expectActivityLaunch, int userId);
+
+    abstract class Stub extends Binder implements IAccountManager {
+        public static IAccountManager asInterface(IBinder obj) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/hidden-api/src/main/java/android/accounts/IAccountManagerResponse.java
+++ b/hidden-api/src/main/java/android/accounts/IAccountManagerResponse.java
@@ -1,0 +1,55 @@
+package android.accounts;
+
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+
+public interface IAccountManagerResponse extends IInterface {
+    void onResult(Bundle value) throws RemoteException;
+    void onError(int errorCode, String errorMessage) throws RemoteException;
+
+    abstract class Stub extends Binder implements IAccountManagerResponse {
+        private static final String DESCRIPTOR = "android.accounts.IAccountManagerResponse";
+
+        public Stub() {
+            attachInterface(this, DESCRIPTOR);
+        }
+
+        @Override
+        public IBinder asBinder() {
+            return this;
+        }
+
+        @Override
+        public boolean onTransact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+            if (code == INTERFACE_TRANSACTION) {
+                reply.writeString(DESCRIPTOR);
+                return true;
+            }
+            switch (code) {
+                case 1: { // onResult
+                    data.enforceInterface(DESCRIPTOR);
+                    Bundle value = null;
+                    if (0 != data.readInt()) {
+                        value = Bundle.CREATOR.createFromParcel(data);
+                    }
+                    onResult(value);
+                    reply.writeNoException();
+                    return true;
+                }
+                case 2: { // onError
+                    data.enforceInterface(DESCRIPTOR);
+                    int errorCode = data.readInt();
+                    String errorMessage = data.readString();
+                    onError(errorCode, errorMessage);
+                    reply.writeNoException();
+                    return true;
+                }
+            }
+            return super.onTransact(code, data, reply, flags);
+        }
+    }
+}

--- a/hidden-api/src/main/java/android/content/pm/IPackageManager.java
+++ b/hidden-api/src/main/java/android/content/pm/IPackageManager.java
@@ -21,6 +21,14 @@ public interface IPackageManager extends IInterface {
     PackageInfo getPackageInfo(String packageName, int flags, int userId)
             throws RemoteException;
 
+    PackageInfo getPackageInfo(String packageName, long flags, int userId)
+            throws RemoteException;
+
+    void setApplicationEnabledSetting(String packageName, int newState, int flags, int userId,
+                                      String callingPackage) throws RemoteException;
+
+    int getApplicationEnabledSetting(String packageName, int userId) throws RemoteException;
+
     int getPackageUid(String packageName, int flags, int userId) throws RemoteException;
 
     String[] getPackagesForUid(int uid)

--- a/hidden-api/src/main/java/android/content/pm/UserInfo.java
+++ b/hidden-api/src/main/java/android/content/pm/UserInfo.java
@@ -1,0 +1,37 @@
+package android.content.pm;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class UserInfo implements Parcelable {
+    public int id;
+
+    public @Nullable String name;
+
+    protected UserInfo(Parcel in) {
+    }
+
+    public static final Creator<UserInfo> CREATOR = new Creator<UserInfo>() {
+        @Override
+        public UserInfo createFromParcel(Parcel in) {
+            return new UserInfo(in);
+        }
+
+        @Override
+        public UserInfo[] newArray(int size) {
+            return new UserInfo[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+    }
+}

--- a/hidden-api/src/main/java/android/os/IUserManager.java
+++ b/hidden-api/src/main/java/android/os/IUserManager.java
@@ -1,7 +1,17 @@
 package android.os;
 
+import android.content.pm.UserInfo;
+
+import java.util.List;
+
 public interface IUserManager extends IInterface {
     void setUserRestriction(String key, boolean value, int userHandle);
+
+    List<UserInfo> getUsers(boolean excludePartial, boolean excludeDying, boolean excludePreCreated);
+
+    List<UserInfo> getUsers(boolean excludeDying);
+
+    boolean removeUser(int userHandle);
 
     abstract class Stub extends Binder implements IUserManager {
         public static IUserManager asInterface(IBinder obj) {

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionCode=19
-versionName=2.12.0
+versionCode=20
+versionName=2.13.0


### PR DESCRIPTION
【功能新增】
新增“用户管理”与“账号管理”配置面板，支持对设备中的全体账户进行快捷查看与隔离。
账号管理页右上角新增“一键冻结 / 一键解冻”智能切换按钮，增加切换到系统设置账户管理界面的快捷方式。
【体验优化】
优化全局页面过渡以及组件状态切换动画。
【Bug修复】
修复了在设备已存在账户时激活 Device Owner 出现“假成功”的判定逻辑漏洞。
补全了通过 Shizuku 激活成功后的主页状态同步刷新，实现即时自动授权与守护进程启动。

[New Feature] Account Manager & Multi-User Support:
Added new User Manager and Account Manager panels to quickly view and isolate all device accounts.
Added a smart "Freeze All / Unfreeze All" toggle button in the upper-right corner of the Account Manager, and added a shortcut to the system account management settings page.
[Optimization] Animation Improvement:
Optimized global page transitions and component state switching animations.
[Bug Fixes] Owner Activation:
Fixed false-positive logic issue when activating Device Owner while existing accounts are present on the device.
Completed homepage status synchronization after successful Shizuku activation, enabling instant auto-authorization and daemon startup.
<img width="1224" height="2700" alt="17788a251e32510c784f3d4ea94435a0" src="https://github.com/user-attachments/assets/bf3ae185-daa4-45ec-931c-dc03b7de50c9" />
<img width="1224" height="2700" alt="7d8e437f8b3d3f8d3a62e86547753efb" src="https://github.com/user-attachments/assets/251cc2f0-a282-4771-8efe-31ddafb21cac" />
<img width="1224" height="2700" alt="673d9c7361c8be514bfd342db4204157" src="https://github.com/user-attachments/assets/ff4dbf20-476e-419b-b3d1-465b2caae233" />


