### PR TITLE
fix: restore device-admin activation through Shizuku and ADB

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,8 @@ ksp {
 dependencies {
     compileOnly(project(":hidden-api"))
 
+    testImplementation("junit:junit:4.13.2")
+
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,7 +118,7 @@
 
         <receiver
             android:name=".server.DhizukuDAReceiver"
-            android:exported="false"
+            android:exported="true"
             android:permission="android.permission.BIND_DEVICE_ADMIN">
             <meta-data
                 android:name="android.app.device_admin"

--- a/app/src/test/java/com/rosan/dhizuku/AndroidManifestTest.kt
+++ b/app/src/test/java/com/rosan/dhizuku/AndroidManifestTest.kt
@@ -1,0 +1,61 @@
+package com.rosan.dhizuku
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+class AndroidManifestTest {
+    @Test
+    fun dhizukuDeviceAdminReceiverMaintainsActivationContract() {
+        val androidNamespace = "http://schemas.android.com/apk/res/android"
+        val manifest = File("src/main/AndroidManifest.xml")
+        val document = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newDocumentBuilder().parse(manifest)
+
+        val receiver = (0 until document.getElementsByTagName("receiver").length)
+            .map { document.getElementsByTagName("receiver").item(it) as Element }
+            .firstOrNull {
+                it.attributes.getNamedItemNS(androidNamespace, "name")?.nodeValue ==
+                    ".server.DhizukuDAReceiver"
+            } ?: throw AssertionError("DhizukuDAReceiver must be declared")
+
+        assertEquals(
+            "true",
+            receiver.attributes.getNamedItemNS(androidNamespace, "exported")?.nodeValue
+        )
+        assertEquals(
+            "android.permission.BIND_DEVICE_ADMIN",
+            receiver.attributes.getNamedItemNS(androidNamespace, "permission")?.nodeValue
+        )
+
+        val metadata = (0 until receiver.childNodes.length)
+            .map { receiver.childNodes.item(it) }
+            .firstOrNull {
+                it.nodeName == "meta-data" &&
+                    it.attributes.getNamedItemNS(androidNamespace, "name")?.nodeValue ==
+                    "android.app.device_admin"
+            } ?: throw AssertionError(
+                "DhizukuDAReceiver must declare device-admin metadata"
+            )
+
+        assertEquals(
+            "@xml/dhizuku_device_admin",
+            metadata.attributes.getNamedItemNS(androidNamespace, "resource")?.nodeValue
+        )
+
+        val actions = (0 until receiver.getElementsByTagName("action").length)
+            .map { receiver.getElementsByTagName("action").item(it) }
+            .mapNotNull {
+                it.attributes.getNamedItemNS(androidNamespace, "name")?.nodeValue
+            }
+
+        assertTrue(
+            "DhizukuDAReceiver must advertise DEVICE_ADMIN_ENABLED",
+            "android.app.action.DEVICE_ADMIN_ENABLED" in actions
+        )
+    }
+}


### PR DESCRIPTION
Change the `DhizukuDAReceiver` manifest declaration so Android's device-policy service can resolve it when activation is initiated outside Dhizuku's process. Preserve the receiver's `android.permission.BIND_DEVICE_ADMIN` guard, device-admin metadata, and existing policy intent filters; that privileged permission remains the access boundary while allowing the system/Shizuku-mediated activation flow to find the receiver. Add a source-manifest regression test that asserts the receiver's complete activation contract—exported visibility, permission, metadata, and `DEVICE_ADMIN_ENABLED` action—rather than checking only the reported literal, and wire the minimal JVM test dependency in the app module. Dhizuku 2.11 stopped appearing as a usable Shizuku client for the reporter on stock Android 14, despite Shizuku running and permission having been granted; the same APK also fails `dpm set-device-owner` with `Bad admin` for `DhizukuDAReceiver`. The reporter states that 2.10.1 worked and supplies the exact failing component, while the current manifest still declares that device-admin receiver as non-exported. Both the Shizuku activation path in `ActivateViewModel` and the displayed ADB command in `HomePage` pass this receiver to `DevicePolicyManager`, so its manifest visibility is shared wiring for both failures. The thread contains no claim or competing PR, and the latest collaborator comment asks whether the problem remains rather than taking ownership.

Testing: On the JVM, parse `app/src/main/AndroidManifest.xml`, locate `.server.DhizukuDAReceiver`, and verify it is exported while still protected by `android.permission.BIND_DEVICE_ADMIN`; Verify the same receiver retains the `android.app.device_admin` metadata pointing to `@xml/dhizuku_device_admin` and advertises `android.app.action.DEVICE_ADMIN_ENABLED`, preventing a future partial manifest edit from recreating `Bad admin`.

Fixes #199
